### PR TITLE
with protected_attributes, some gems cannot failed

### DIFF
--- a/comfy_imprint.gemspec
+++ b/comfy_imprint.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'haml', '~> 4.0'
   s.add_dependency 'simple_form', '~> 3.0'
   s.add_dependency 'kaminari', '~> 0.15'
-  s.add_dependency 'protected_attributes'
+  # s.add_dependency 'protected_attributes'
 
   # s.add_dependency "jquery-rails"
 


### PR DESCRIPTION
I found the protected_attributes is not necessary.
